### PR TITLE
fix: change the keyword herb to herbs in the package.json file

### DIFF
--- a/src/templates/package.json.ejs
+++ b/src/templates/package.json.ejs
@@ -9,7 +9,7 @@
       "lint": "npx eslint \"**/*.{js,jsx}\" --quiet",
       "lint:fix": "npx eslint \"**/*.{js,jsx}\" --fix"<%- props.migration %>
     },
-    "keywords": ["herb"],
+    "keywords": ["herbs"],
     "author": "<%= props.author %>",
     "license": "<%= props.license %>",
     "dependencies": {


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

# Fixes
The word "herbs" was written "herb" in the keywords array in the `package.json` file.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Change the word "herb" to "herbs" in the `package.json` file;
2. Question: do you guys think it's a good ideia to also add herbsjs to the keywords array? Or only herbs is fine?

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`


No breaking changes or coverage decrease in this pull request.
