### PR TITLE
fix: removes single quotes from REST endpoints

### DIFF
--- a/src/templates/infra/api/rest/index.ejs
+++ b/src/templates/infra/api/rest/index.ejs
@@ -8,17 +8,17 @@ const renderShelfHTML = require('@herbsjs/herbsshelf')
 const { generateRoutes } = require('@herbsjs/herbs2rest')
 const repositoriesFactory = require('../../../infra/data/repositories')
 
-function cloneUsecases(usecases){
+function cloneUsecases (usecases) {
     return Promise.all(usecases.map(uc => {
-        const clonedUC = { ...uc}
+        const clonedUC = { ...uc }
         clonedUC.usecase = clonedUC.usecase({})()
         return clonedUC
     }))
 }
 
-const newRoute = (usecase, useId) => { 
+const newRoute = (usecase, useId) => {
     const route = { usecase }
-    if(useId) route.id = 'id'
+    if (useId) route.id = 'id'
     return route
 }
 const mapUcToHTTPVerb = {
@@ -40,8 +40,8 @@ const mapUcToHTTPVerb = {
     },
 }
 
-async function prepareRoutes(config){
-    const conn = await db.factory(config) 
+async function prepareRoutes (config) {
+    const conn = await db.factory(config)
     const repositories = await repositoriesFactory(conn)
 
     // groupBy group
@@ -53,24 +53,24 @@ async function prepareRoutes(config){
 
     const routes = Object.keys(ucByGroup).map(group => {
         const route = {
-            name: `'${camelCase(group)}'`
+            name: `${camelCase(group)}`
         }
         for (const obj of ucByGroup[group]) {
             const uc = obj.usecase(repositories)
             const ucDescription = uc().description.toLowerCase()
-            
-            for(const ucType of Object.keys(mapUcToHTTPVerb))
-                if (ucDescription.includes(ucType)) 
+
+            for (const ucType of Object.keys(mapUcToHTTPVerb))
+                if (ucDescription.includes(ucType))
                     route[mapUcToHTTPVerb[ucType].route] = newRoute(uc, mapUcToHTTPVerb[ucType].useId)
         }
         return route
     })
-    
+
     return Promise.all(routes)
 }
 
 module.exports = async (app, config) => {
-    app.use(json({limit: '50mb'}))
+    app.use(json({ limit: '50mb' }))
     app.use(cors())
 
     const router = new express.Router()


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #67 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Removes single quotes from REST endpoints' names

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [X] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`


I removed the quotes altogether:

![image](https://user-images.githubusercontent.com/10438122/136850471-c7cd4e85-953c-4059-ad8c-823ddc06a6fd.png)
