### PR TITLE
fix: change updateUsecase to return Err.notFound when the entity doesnt exist

### DIFF
--- a/src/templates/domain/useCases/tests/update.test.ejs
+++ b/src/templates/domain/useCases/tests/update.test.ejs
@@ -2,7 +2,6 @@ const update<%= props.name.pascalCase %> = require('./update<%= props.name.pasca
 const assert = require('assert')
 const { <%= props.name.pascalCase %> } = require('../../entities')
 
-
 describe('Update <%= props.name.pascalCase %>', () => {
   function aUser({ hasAccess }) {
     return { hasAccess }
@@ -21,7 +20,7 @@ describe('Update <%= props.name.pascalCase %>', () => {
       }
       const user = aUser({ hasAccess: true })
       /*{ <%= props.request %> }*/
-      const req = {  id: 5, nickname: 'herbsUser', password: 'V&eryStr0ngP@$$'}
+      const req = { id: 5, nickname: 'herbsUser', password: 'V&eryStr0ngP@$$'}
 
       // When
       const uc = update<%= props.name.pascalCase %>(injection)()
@@ -41,7 +40,7 @@ describe('Update <%= props.name.pascalCase %>', () => {
       const injection = {}
       const user = aUser({ hasAccess: true })
       /*{ <%= props.request %> }*/
-      const req = {  nickname: 'herbsUser', password: 96587422 }
+      const req = { nickname: 'herbsUser', password: 96587422 }
 
       // When
       const uc = update<%= props.name.pascalCase %>(injection)()
@@ -51,6 +50,29 @@ describe('Update <%= props.name.pascalCase %>', () => {
       // Then
       assert.ok(ret.isErr)
       assert.deepStrictEqual(ret.err, {request :[{password:[{wrongType:"String"}]}]})
+    })
+
+    it('should not update non existing <%= props.name.pascalCase %>', async () => {
+      // Given
+      const retInjection = null
+      const injection = {
+        <%= props.name.camelCase %>Repository: new ( class <%= props.name.camelCase %>Repository {
+          async findByID(id) { return (retInjection) }
+          async update(id) { return true }
+        })
+      }
+      const user = aUser({ hasAccess: true })
+      /*{ <%= props.request %> }*/
+      const req = { id: 0, nickname: 'herbsUser', password: 'V&eryStr0ngP@$$' }
+
+      // When
+      const uc = update<%= props.name.pascalCase %>(injection)()
+      await uc.authorize(<%= props.name.camelCase %>)
+      const ret = await uc.run(req)
+
+      // Then
+      assert.ok(ret.isErr)
+      assert.ok(ret.isNotFoundError)
     })
   })
 })

--- a/src/templates/domain/useCases/update.ejs
+++ b/src/templates/domain/useCases/update.ejs
@@ -18,18 +18,29 @@ const useCase = ({ <%= props.name.camelCase %>Repository }) => () =>
     authorize: () => Ok(),
 
     //Step description and function
-    'Check if the <%= props.name.raw %> is valid': step(async ctx => {
+    'Check if the <%= props.name.raw %> exists': step(async ctx => {
       const <%= props.name.camelCase %> = await <%= props.name.camelCase %>Repository.findByID(parseInt(ctx.req.id))
+      
+      if (!<%= props.name.camelCase %>) return Err.notFound({
+        message: 'The <%= props.name.pascalCase %> entity is invalid',
+        payload: { entity: '<%= props.name.raw %>' }
+      })
+
       const new<%= props.name.pascalCase %> = merge.all([ <%= props.name.camelCase %>, ctx.req ])
       ctx.<%= props.name.camelCase %> = <%= props.name.pascalCase %>.fromJSON(new<%= props.name.pascalCase %>)
+      
+      // returning Ok continues to the next step. Err stops the use case execution.
+      return Ok() 
+    }),
 
+    //Step description and function
+    'Check if the <%= props.name.raw %> is valid': step(async ctx => {
       if (!ctx.<%= props.name.camelCase %>.isValid()) return Err.invalidEntity({
         message: 'The <%= props.name.pascalCase %> entity is invalid', 
         payload: { entity: '<%= props.name.raw %>' },  
         cause: ctx.<%= props.name.camelCase %>.errors
       })
       
-      // returning Ok continues to the next step. Err stops the use case execution.
       return Ok() 
     }),
 


### PR DESCRIPTION
Change updateUsecase to return Err.notFound when the entity doesnt exist

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #71 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Change the updateUseCase to return the Err.notFound error when the entity doesn't exist
2. Change the unit test for the updateUseCase


## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [X] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
