### PR TITLE
fix: herbs graphql layer dont have inputs types

### DIFF
--- a/src/templates/infra/api/graphql/types.ejs
+++ b/src/templates/infra/api/graphql/types.ejs
@@ -1,4 +1,4 @@
-const { entity2type } = require('@herbsjs/herbs2gql')
+const { entity2type, entity2input } = require('@herbsjs/herbs2gql')
 const { herbarium } = require('@herbsjs/herbarium')
 const { GraphQLDateTime } = require('graphql-scalars')
 
@@ -22,12 +22,14 @@ function types() {
 
   /* Domain Types */
   const entities = Array.from(herbarium.entities.all.values()).map(e => e.entity)
-  types = types.concat(entities.map(entity => [entity2type(entity)]))
+  const entitiesTypes = types.concat(entities.map(entity => [entity2type(entity)]))
+  const entitiesInputs = types.concat(entities.map(entity => [entity2input(entity)]))
 
   /* Custom Types */
-  // types.push(require('./custom/type'))
+  // entitiesTypes.push(require('./custom/type'))
+  // entitiesInputs.push(require('./custom/type'))
 
-  return types
+  return types.concat(entitiesTypes, entitiesInputs)
 }
 
 module.exports = types


### PR DESCRIPTION
I didn't open an issue for this because I fixed it when I got the problem.

The problem:
when we works with nested items like this
``` js
const Party =
        entity('Party', {
          id: id(Number),
          address: field(String),
          hour: field(Date),
          attendees: field([Attendee]),
          items: field([Item])
        })
```

we must to create an `input` type for the graphql layer

so basically, I'm generating an input type for all entities

