### PR TITLE
update lib version to work with SQL Server

### DIFF
--- a/src/generators/src/packagejson.js
+++ b/src/generators/src/packagejson.js
@@ -4,7 +4,7 @@ const optionalPackages = {
   mongo: ['"@herbsjs/herbs2mongo": "^3.0.3"', '"mongodb": "^4.8.1"'],
   postgres: ['"@herbsjs/herbs2knex": "^1.5.7"', '"pg": "^8.7.3"'],
   sqlite: ['"@herbsjs/herbs2knex": "^1.5.7"', '"sqlite3": "^5.0.11"'],
-  sqlserver: ['"@herbsjs/herbs2knex": "^1.5.7"', '"tedious": "^14.6.0"', '"mssql": "^8.1.2"'],
+  sqlserver: ['"@herbsjs/herbs2knex": "^1.5.7"', '"tedious": "^15.1.0"', '"mssql": "^9.0.1"'],
   mysql: ['"@herbsjs/herbs2knex": "^1.5.7"', '"mysql2": "^2.3.3"'],
   rest: ['"express": "^4.18.1"', '"cors": "^2.8.5"', '"@herbsjs/herbs2rest": "^3.2.1"'],
   graphql: ['"graphql": "^16.5.0"', '"@herbsjs/herbs2gql": "^2.3.0"', '"apollo-server": "^3.8.2"','"apollo-server-express": "^3.8.2"', '"graphql-tools": "^8.2.12"', '"graphql-scalars": "^1.17.0"',]


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes
Fixes #161 

1. Update libs tedious and mssql

## Scenery

We have this error bellow when we try to create a template with Herbs and SQL Server

![image](https://user-images.githubusercontent.com/112962515/192800052-c97c532f-4944-45f6-a332-16640c69702d.png)

To resolve this error above we updated tedious to 15.1.0 and mssql to 9.0.1

