### PR TITLE
fix env port to deploy api

### DIFF
--- a/src/templates/infra/config/api.ejs
+++ b/src/templates/infra/config/api.ejs
@@ -1,7 +1,7 @@
 const env = require('sugar-env')
 require('dotenv').config()
 
-var port = process.env.PORT || 3000;
+const port = process.env.PORT || 3000;
 
 module.exports = {
 port: env.get(['GRAPHQL_PORT', 'API_PORT'],port ),

--- a/src/templates/infra/config/api.ejs
+++ b/src/templates/infra/config/api.ejs
@@ -1,10 +1,12 @@
 const env = require('sugar-env')
 require('dotenv').config()
 
+var port = process.env.PORT || 3000;
+
 module.exports = {
-  port: env.get(['GRAPHQL_PORT', 'API_PORT'], 3000),
-  host: env.get(['GRAPHQL_HOST', 'API_HOST'], '0.0.0.0'),
-  graphql: { // TODO:  remove it if not necessary
-    rootPath: env.get(['GRAPHQL_ROOT_PATH', 'GRAPHQL_PATH', 'GRAPHL_ROOT'], '/graphql')
-  }
+port: env.get(['GRAPHQL_PORT', 'API_PORT'],port ),
+host: env.get(['GRAPHQL_HOST', 'API_HOST'], '0.0.0.0'),
+graphql: { // TODO: remove it if not necessary
+rootPath: env.get(['GRAPHQL_ROOT_PATH', 'GRAPHQL_PATH', 'GRAPHL_ROOT'], '/graphql')
+}
 }


### PR DESCRIPTION
Fixes https://github.com/herbsjs/herbs-cli/issues/167

# Describe the bug

When I try to deploy the API GraphQL or Rest, We have a problem because the file api.js dosent have the process.env.PORT to get the correct port from the server

# To reproduce
Try to deploy the project without docker to reproduce this error, the server will get timeout because the port that app listen is 3000

