### PR TITLE
Updated version of herbsjs and glues

### DIFF
--- a/src/generators/src/packagejson.js
+++ b/src/generators/src/packagejson.js
@@ -1,13 +1,13 @@
 const { objToString } = require('../utils')
 
 const optionalPackages = {
-  mongo: ['"@herbsjs/herbs2mongo": "^3.0.3"', '"mongodb": "^4.8.1"'],
-  postgres: ['"@herbsjs/herbs2knex": "^1.5.7"', '"pg": "^8.7.3"'],
-  sqlite: ['"@herbsjs/herbs2knex": "^1.5.7"', '"sqlite3": "^5.0.11"'],
-  sqlserver: ['"@herbsjs/herbs2knex": "^1.5.7"', '"tedious": "^15.1.0"', '"mssql": "^9.0.1"'],
-  mysql: ['"@herbsjs/herbs2knex": "^1.5.7"', '"mysql2": "^2.3.3"'],
-  rest: ['"express": "^4.18.1"', '"cors": "^2.8.5"', '"@herbsjs/herbs2rest": "^3.2.1"'],
-  graphql: ['"graphql": "^16.5.0"', '"@herbsjs/herbs2gql": "^2.3.0"', '"apollo-server": "^3.8.2"','"apollo-server-express": "^3.8.2"', '"graphql-tools": "^8.2.12"', '"graphql-scalars": "^1.17.0"',]
+  mongo: ['"@herbsjs/herbs2mongo": "^4.0.0"', '"mongodb": "^4.8.1"'],
+  postgres: ['"@herbsjs/herbs2knex": "^2.1.1"', '"pg": "^8.7.3"'],
+  sqlite: ['"@herbsjs/herbs2knex": "^2.1.1"', '"sqlite3": "^5.0.11"'],
+  sqlserver: ['"@herbsjs/herbs2knex": "^2.1.1"', '"tedious": "^15.1.0"', '"mssql": "^9.0.1"'],
+  mysql: ['"@herbsjs/herbs2knex": "^2.1.1"', '"mysql2": "^2.3.3"'],
+  rest: ['"express": "^4.18.1"', '"cors": "^2.8.5"', '"@herbsjs/herbs2rest": "^4.1.1"'],
+  graphql: ['"graphql": "^16.5.0"', '"@herbsjs/herbs2gql": "^3.0.0"', '"apollo-server": "^3.8.2"','"apollo-server-express": "^3.8.2"', '"graphql-tools": "^8.2.12"', '"graphql-scalars": "^1.17.0"',]
 }
 
 const defaultOptions = (options) => {
@@ -46,9 +46,9 @@ module.exports =
         : ''
 
       let packages = [
-        '"@herbsjs/herbs": "^1.6.2"',
-        '"@herbsjs/herbarium": "^1.4.0"',
-        '"@herbsjs/herbsshelf": "^4.0.1"',
+        '"@herbsjs/herbs": "^2.0.0"',
+        '"@herbsjs/herbarium": "^1.5.0"',
+        '"@herbsjs/herbsshelf": "^5.0.1"',
         '"dotenv": "^16.0.1"',
         '"deepmerge": "^4.2.2"',
         '"nodemon": "^2.0.19"',

--- a/src/templates/domain/useCases/create.ejs
+++ b/src/templates/domain/useCases/create.ejs
@@ -17,18 +17,21 @@ const create<%- props.name.pascalCase %> = injection =>
     // authorize: (user) => (user.canCreate<%- props.name.pascalCase %> ? Ok() : Err()),
     authorize: () => Ok(),
 
-    setup: ctx => (ctx.di = Object.assign({}, dependency, injection)),
+    setup: ctx => {
+      ctx.di = Object.assign({}, dependency, injection)
+      ctx.data = {}
+    },
 
     //Step description and function
     'Check if the <%- props.name.raw %> is valid': step(ctx => {
-      ctx.<%- props.name.camelCase %> = <%- props.name.pascalCase %>.fromJSON(ctx.req)
-      <% if(!props.mongo){ %>ctx.<%- props.name.camelCase %>.id = Math.floor(Math.random() * 100000).toString()<% } %>
+      ctx.data.<%- props.name.camelCase %> = <%- props.name.pascalCase %>.fromJSON(ctx.req)
+      <% if(!props.mongo){ %>ctx.data.<%- props.name.camelCase %>.id = Math.floor(Math.random() * 100000).toString()<% } %>
       
-      if (!ctx.<%- props.name.camelCase %>.isValid()) 
+      if (!ctx.data.<%- props.name.camelCase %>.isValid()) 
         return Err.invalidEntity({
           message: 'The <%- props.name.raw %> entity is invalid', 
           payload: { entity: '<%- props.name.raw %>' },
-          cause: ctx.<%- props.name.camelCase %>.errors 
+          cause: ctx.data.<%- props.name.camelCase %>.errors 
         })
 
       // returning Ok continues to the next step. Err stops the use case execution.
@@ -37,7 +40,7 @@ const create<%- props.name.pascalCase %> = injection =>
 
     'Save the <%- props.name.raw %>': step(async ctx => {
       const repo = new ctx.di.<%- props.name.pascalCase %>Repository(injection)
-      const <%- props.name.camelCase %> = ctx.<%- props.name.camelCase %>
+      const <%- props.name.camelCase %> = ctx.data.<%- props.name.camelCase %>
       // ctx.ret is the return value of a use case
       return (ctx.ret = await repo.insert(<%- props.name.camelCase %>))
     })

--- a/src/templates/domain/useCases/delete.ejs
+++ b/src/templates/domain/useCases/delete.ejs
@@ -19,12 +19,15 @@ const delete<%- props.name.pascalCase %> = injection =>
     // authorize: (user) => (user.canDelete<%- props.name.pascalCase %> ? Ok() : Err()),
     authorize: () => Ok(),
 
-    setup: ctx => (ctx.di = Object.assign({}, dependency, injection)),
+    setup: ctx => {
+      ctx.di = Object.assign({}, dependency, injection)
+      ctx.data = {}
+    },
 
     'Check if the <%- props.name.pascalCase %> exist': step(async ctx => {
       const repo = new ctx.di.<%- props.name.pascalCase %>Repository(injection)
       const [<%- props.name.camelCase %>] = await repo.findByID(ctx.req.id)
-      ctx.<%- props.name.camelCase %> = <%- props.name.camelCase %>
+      ctx.data.<%- props.name.camelCase %> = <%- props.name.camelCase %>
 
       if (<%- props.name.camelCase %>) return Ok()
       return Err.notFound({
@@ -35,7 +38,7 @@ const delete<%- props.name.pascalCase %> = injection =>
 
     'Delete the <%- props.name.pascalCase %>': step(async ctx => {
       const repo = new ctx.di.<%- props.name.pascalCase %>Repository(injection)
-      ctx.ret = await repo.delete(ctx.<%- props.name.camelCase %>)
+      ctx.ret = await repo.delete(ctx.data.<%- props.name.camelCase %>)
       // ctx.ret is the return value of a use case
       return Ok(ctx.ret)
     })

--- a/src/templates/domain/useCases/update.ejs
+++ b/src/templates/domain/useCases/update.ejs
@@ -18,13 +18,16 @@ const update<%- props.name.pascalCase %> = injection =>
     // authorize: (user) => (user.canUpdate<%- props.name.pascalCase %> ? Ok() : Err()),
     authorize: () => Ok(),
 
-    setup: ctx => (ctx.di = Object.assign({}, dependency, injection)),
+    setup: ctx => {
+      ctx.di = Object.assign({}, dependency, injection)
+      ctx.data = {}
+    },
 
     'Retrieve the <%- props.name.raw %>': step(async ctx => {
       const id = ctx.req.id
       const repo = new ctx.di.<%- props.name.pascalCase %>Repository(injection)
       const [<%- props.name.camelCase %>] = await repo.findByID(id)
-      ctx.<%- props.name.camelCase %> = <%- props.name.camelCase %>
+      ctx.data.<%- props.name.camelCase %> = <%- props.name.camelCase %>
       if (<%- props.name.camelCase %> === undefined) return Err.notFound({
         message: `<%- props.name.pascalCase %> not found - ID: ${id}`,
         payload: { entity: '<%- props.name.raw %>' }
@@ -34,9 +37,9 @@ const update<%- props.name.pascalCase %> = injection =>
     }),
 
     'Check if it is a valid <%- props.name.raw %> before update': step(ctx => {
-      const old<%- props.name.pascalCase %> = ctx.<%- props.name.camelCase %>
+      const old<%- props.name.pascalCase %> = ctx.data.<%- props.name.camelCase %>
       const new<%- props.name.pascalCase %> = <%- props.name.pascalCase %>.fromJSON(merge.all([ old<%- props.name.pascalCase %>, ctx.req ]))
-      ctx.<%- props.name.camelCase %> = new<%- props.name.pascalCase %>
+      ctx.data.<%- props.name.camelCase %> = new<%- props.name.pascalCase %>
 
       return new<%- props.name.pascalCase %>.isValid() ? Ok() : Err.invalidEntity({
         message: `<%- props.name.pascalCase %> is invalid`,
@@ -49,7 +52,7 @@ const update<%- props.name.pascalCase %> = injection =>
     'Update the <%- props.name.pascalCase %>': step(async ctx => {
       const repo = new ctx.di.<%- props.name.pascalCase %>Repository(injection)
       // ctx.ret is the return value of a use case
-      return (ctx.ret = await repo.update(ctx.<%- props.name.camelCase %>))
+      return (ctx.ret = await repo.update(ctx.data.<%- props.name.camelCase %>))
     })
 
   })


### PR DESCRIPTION
The use of ctx.data instead of ctx.user makes a project created with `herbs new` not have problems with the user feature inside ctx.user implemented in version 2.0.0 of buchu.
Refer to: https://github.com/herbsjs/buchu/pull/85

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Update herbs to ^2.0.0
2. Update herbarium to ^1.5.0
3. Update herbsshelf to ^5.0.1
4. Update herbs2mongo to ^4.0.0
5. Update herbs2knex to ^2.1.1
6. Update herbs2gql to ^3.0.0
7. Update herbs2rest to ^4.1.1
8. Usecase template should use ctx.data

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
