### PR TITLE
feat: generate id field using uuid

### DIFF
--- a/src/generators/src/packagejson.js
+++ b/src/generators/src/packagejson.js
@@ -54,8 +54,7 @@ module.exports =
         '"nodemon": "^2.0.19"',
         '"mocha": "^10.0.0"',
         '"lodash.camelcase": "^4.3.0"',
-        '"sugar-env": "^1.5.14"',
-        '"uuid": "^9.0.0"'
+        '"sugar-env": "^1.5.14"'
       ]
 
       for (const key of Object.keys(options)) {

--- a/src/generators/src/packagejson.js
+++ b/src/generators/src/packagejson.js
@@ -54,7 +54,8 @@ module.exports =
         '"nodemon": "^2.0.19"',
         '"mocha": "^10.0.0"',
         '"lodash.camelcase": "^4.3.0"',
-        '"sugar-env": "^1.5.14"'
+        '"sugar-env": "^1.5.14"',
+        '"uuid": "^9.0.0"'
       ]
 
       for (const key of Object.keys(options)) {

--- a/src/templates/domain/useCases/create.ejs
+++ b/src/templates/domain/useCases/create.ejs
@@ -8,7 +8,7 @@ const dependency = { <%- props.name.pascalCase %>Repository }
 
 const create<%- props.name.pascalCase %> = injection =>
   usecase('Create <%- props.name.pascalCase %>', {
-    // Input/Request metadata and validation
+    // Input/Request metadata and validation 
     request: request.from(<%- props.name.pascalCase %>, { ignoreIDs: true }),
 
     // Output/Response metadata

--- a/src/templates/domain/useCases/create.ejs
+++ b/src/templates/domain/useCases/create.ejs
@@ -3,11 +3,12 @@ const { herbarium } = require('@herbsjs/herbarium')
 const <%- props.name.pascalCase %> = require('../../entities/<%- props.name.camelCase %>')
 const <%- props.name.pascalCase %>Repository = require('../../../infra/data/repositories/<%- props.name.camelCase %>Repository')
 
+const uuid = require('uuid')
 const dependency = { <%- props.name.pascalCase %>Repository }
 
 const create<%- props.name.pascalCase %> = injection =>
   usecase('Create <%- props.name.pascalCase %>', {
-    // Input/Request metadata and validation 
+    // Input/Request metadata and validation
     request: request.from(<%- props.name.pascalCase %>, { ignoreIDs: true }),
 
     // Output/Response metadata
@@ -22,17 +23,16 @@ const create<%- props.name.pascalCase %> = injection =>
     //Step description and function
     'Check if the <%- props.name.raw %> is valid': step(ctx => {
       ctx.<%- props.name.camelCase %> = <%- props.name.pascalCase %>.fromJSON(ctx.req)
-      <% if(!props.mongo){ %>ctx.<%- props.name.camelCase %>.id = Math.floor(Math.random() * 100000).toString()<% } %>
-      
-      if (!ctx.<%- props.name.camelCase %>.isValid()) 
+      ctx.<%- props.name.camelCase %>.id = uuid.v4()
+      if (!ctx.<%- props.name.camelCase %>.isValid())
         return Err.invalidEntity({
-          message: 'The <%- props.name.raw %> entity is invalid', 
+          message: 'The <%- props.name.raw %> entity is invalid',
           payload: { entity: '<%- props.name.raw %>' },
-          cause: ctx.<%- props.name.camelCase %>.errors 
+          cause: ctx.<%- props.name.camelCase %>.errors
         })
 
       // returning Ok continues to the next step. Err stops the use case execution.
-      return Ok() 
+      return Ok()
     }),
 
     'Save the <%- props.name.raw %>': step(async ctx => {

--- a/src/templates/domain/useCases/create.ejs
+++ b/src/templates/domain/useCases/create.ejs
@@ -1,9 +1,9 @@
 const { usecase, step, Ok, Err, request } = require('@herbsjs/herbs')
 const { herbarium } = require('@herbsjs/herbarium')
+const { randomUUID } = require('crypto')
 const <%- props.name.pascalCase %> = require('../../entities/<%- props.name.camelCase %>')
 const <%- props.name.pascalCase %>Repository = require('../../../infra/data/repositories/<%- props.name.camelCase %>Repository')
 
-const uuid = require('uuid')
 const dependency = { <%- props.name.pascalCase %>Repository }
 
 const create<%- props.name.pascalCase %> = injection =>
@@ -23,7 +23,7 @@ const create<%- props.name.pascalCase %> = injection =>
     //Step description and function
     'Check if the <%- props.name.raw %> is valid': step(ctx => {
       ctx.<%- props.name.camelCase %> = <%- props.name.pascalCase %>.fromJSON(ctx.req)
-      ctx.<%- props.name.camelCase %>.id = uuid.v4()
+      ctx.<%- props.name.camelCase %>.id = randomUUID()
       if (!ctx.<%- props.name.camelCase %>.isValid())
         return Err.invalidEntity({
           message: 'The <%- props.name.raw %> entity is invalid',


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #158 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. **Replace** `uuid` **package with the native Node.js** `crypto` **module**:
- Removed the dependency on `uuid` package from package.json.
- Updated all UUID generation to use the native `randomUUID()` function from the Node.js crypto module.

2. **Update Migration Generation for UUID Handling:**
- Improved migration generation logic to handle UUID columns appropriately based on the database.
- For PostgreSQL, the id field is generated using uuid_generate_v4() as the default value for primary keys.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Remember to check if code coverage decreases, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`